### PR TITLE
Replace space.Object with space.Entity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/go-github/v32 v32.1.0
 	github.com/google/uuid v1.2.0 // indirect
-	github.com/milosgajdos/netscrape v0.0.5-0.20210303202446-8dd2f3abecfd
+	github.com/milosgajdos/netscrape v0.0.5-0.20210306112842-a0a6c175ce1b
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/go-github/v32 v32.1.0
 	github.com/google/uuid v1.2.0 // indirect
-	github.com/milosgajdos/netscrape v0.0.5-0.20210306112842-a0a6c175ce1b
+	github.com/milosgajdos/netscrape v0.0.5-0.20210306113940-e77f6d0688d2
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
 	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c // indirect

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/milosgajdos/netscrape v0.0.5-0.20210303202446-8dd2f3abecfd h1:+Hsyd1gcXyeacNz0lFhi7hVZr5OHW/4YaA1A3htCjRE=
-github.com/milosgajdos/netscrape v0.0.5-0.20210303202446-8dd2f3abecfd/go.mod h1:tZuYOuxy0jomiNHlavIKzDrDo/wks4ply+KNKE/zFJM=
+github.com/milosgajdos/netscrape v0.0.5-0.20210306112842-a0a6c175ce1b h1:Y8D31vDfHBYsj5jTJkBhEopgU3l0O3TvZ4ZokivoEDU=
+github.com/milosgajdos/netscrape v0.0.5-0.20210306112842-a0a6c175ce1b/go.mod h1:tZuYOuxy0jomiNHlavIKzDrDo/wks4ply+KNKE/zFJM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/milosgajdos/netscrape v0.0.5-0.20210306112842-a0a6c175ce1b h1:Y8D31vDfHBYsj5jTJkBhEopgU3l0O3TvZ4ZokivoEDU=
 github.com/milosgajdos/netscrape v0.0.5-0.20210306112842-a0a6c175ce1b/go.mod h1:tZuYOuxy0jomiNHlavIKzDrDo/wks4ply+KNKE/zFJM=
+github.com/milosgajdos/netscrape v0.0.5-0.20210306113940-e77f6d0688d2 h1:gAiCvA2wcqRz40lKupoEzjCBezCP9CNdMPc7LFYHhp4=
+github.com/milosgajdos/netscrape v0.0.5-0.20210306113940-e77f6d0688d2/go.mod h1:tZuYOuxy0jomiNHlavIKzDrDo/wks4ply+KNKE/zFJM=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/space/gh/star/scraper.go
+++ b/space/gh/star/scraper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/milosgajdos/netscrape/pkg/query/base"
 	"github.com/milosgajdos/netscrape/pkg/query/predicate"
 	"github.com/milosgajdos/netscrape/pkg/space"
-	"github.com/milosgajdos/netscrape/pkg/space/object"
+	"github.com/milosgajdos/netscrape/pkg/space/entity"
 	"github.com/milosgajdos/netscrape/pkg/space/plan"
 	"github.com/milosgajdos/netscrape/pkg/space/resource"
 	"github.com/milosgajdos/netscrape/pkg/space/top"
@@ -139,7 +139,7 @@ func (s *scraper) addEntities(ctx context.Context, top space.Top, names []string
 			return nil, err
 		}
 
-		entities[i], err = object.New(strings.ToLower(name), ns, r, object.WithUID(uid))
+		entities[i], err = entity.New(strings.ToLower(name), ns, r, entity.WithUID(uid))
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func (s *scraper) mapRepos(ctx context.Context, reposChan <-chan []*github.Starr
 				return err
 			}
 
-			repoEnt, err := object.New(*repo.Repository.Name, ns, resMap[repoRes], object.WithUID(uid), object.WithAttrs(a))
+			repoEnt, err := entity.New(*repo.Repository.Name, ns, resMap[repoRes], entity.WithUID(uid), entity.WithAttrs(a))
 			if err != nil {
 				return err
 			}
@@ -195,7 +195,7 @@ func (s *scraper) mapRepos(ctx context.Context, reposChan <-chan []*github.Starr
 				return err
 			}
 
-			ownerEnt, err := object.New(owner, ns, resMap[ownerRes], object.WithUID(ownerUID))
+			ownerEnt, err := entity.New(owner, ns, resMap[ownerRes], entity.WithUID(ownerUID))
 			if err != nil {
 				return err
 			}

--- a/store/dgraph/helpers_test.go
+++ b/store/dgraph/helpers_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/milosgajdos/netscrape/pkg/attrs"
 	"github.com/milosgajdos/netscrape/pkg/space"
-	"github.com/milosgajdos/netscrape/pkg/space/object"
+	"github.com/milosgajdos/netscrape/pkg/space/entity"
 	"github.com/milosgajdos/netscrape/pkg/space/resource"
 	"github.com/milosgajdos/netscrape/pkg/uuid"
 )
@@ -31,7 +31,7 @@ func newTestResource(name, group, version, kind string, namespaced bool, opts ..
 	return resource.New(name, group, version, kind, namespaced, resource.WithUID(uid))
 }
 
-func newTestObject(entName, entNs string) (space.Object, error) {
+func newTestEntity(entName, entNs string) (space.Entity, error) {
 	r, err := newTestResource(resName, resGroup, resVersion, resKind, true)
 	if err != nil {
 		return nil, err
@@ -42,7 +42,7 @@ func newTestObject(entName, entNs string) (space.Object, error) {
 		return nil, err
 	}
 
-	return object.New(entName, entNs, r, object.WithUID(uid))
+	return entity.New(entName, entNs, r, entity.WithUID(uid))
 }
 
 func TestAttrsToMap(t *testing.T) {
@@ -79,7 +79,7 @@ func TestContains(t *testing.T) {
 }
 
 func TestDecodeJSONEntity(t *testing.T) {
-	testFiles := []string{"object.json", "resource.json"}
+	testFiles := []string{"entity.json", "resource.json"}
 
 	for _, f := range testFiles {
 		path := path.Join(testDir, f)

--- a/store/dgraph/operations.go
+++ b/store/dgraph/operations.go
@@ -1,0 +1,37 @@
+package dgraph
+
+// Op is dgraph operation.
+type Op int
+
+const (
+	// AddOp is add operation
+	AddOp Op = iota
+	// DelOp is delete operation
+	DelOp
+	// GetOp is get operation
+	GetOp
+	// LinkOp is link operation
+	LinkOp
+	// UnlinkOp is unlink operation
+	UnlinkOp
+	// UnknownOp is unknown operation
+	UnknownOp
+)
+
+// String implements fmt.Stringer.
+func (op Op) String() string {
+	switch op {
+	case AddOp:
+		return "AddOp"
+	case DelOp:
+		return "DelOp"
+	case GetOp:
+		return "GetOp"
+	case LinkOp:
+		return "LinkOp"
+	case UnlinkOp:
+		return "UnlinkOp"
+	default:
+		return "UnknownOp"
+	}
+}

--- a/store/dgraph/schema.go
+++ b/store/dgraph/schema.go
@@ -1,9 +1,10 @@
 package dgraph
 
-// SpaceDQLSchema is space DQL schema
+// SpaceDQLSchema defines schema.
 const SpaceDQLSchema = `
-	type Object {
+	type Entity {
 		xid
+		type
 		name
 		namespace
 		resource
@@ -12,6 +13,7 @@ const SpaceDQLSchema = `
 
 	type Resource {
 		xid
+		type
 		name
 		group
 		version
@@ -20,6 +22,7 @@ const SpaceDQLSchema = `
 	}
 
 	xid: string @index(exact) .
+	type: string @index(exact) .
 	name: string @index(exact) .
 	namespace: string @index(exact) .
 	links: [uid] @count @reverse .

--- a/store/dgraph/store.go
+++ b/store/dgraph/store.go
@@ -76,11 +76,11 @@ func (s *Store) Get(ctx context.Context, uid uuid.UID, opts ...store.Option) (st
 	}
 
 	if len(ents) == 0 {
-		return nil, store.ErrNodeNotFound
+		return nil, store.ErrEntityNotFound
 	}
 
 	if len(ents) > 2 {
-		panic("duplicate nodes")
+		panic("duplicate entities")
 	}
 
 	return ents[0], nil

--- a/store/dgraph/store_test.go
+++ b/store/dgraph/store_test.go
@@ -62,7 +62,7 @@ func TestAdd(t *testing.T) {
 		s := MustNewStore(*host, *drop, t)
 		defer s.Close()
 
-		obj, err := newTestObject("ent1", "entNs")
+		obj, err := newTestEntity("ent1", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -100,7 +100,7 @@ func TestGet(t *testing.T) {
 		s := MustNewStore(*host, *drop, t)
 		defer s.Close()
 
-		obj, err := newTestObject("ent1", "entNs")
+		obj, err := newTestEntity("ent1", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -118,12 +118,12 @@ func TestGet(t *testing.T) {
 			t.Fatalf("got: %s, want: %s", e.UID(), obj.UID())
 		}
 
-		if !reflect.DeepEqual(obj, e.(space.Object)) {
-			t.Fatalf("expected: %v, got: %v", obj, e.(space.Object))
+		if !reflect.DeepEqual(obj, e.(space.Entity)) {
+			t.Fatalf("expected: %v, got: %v", obj, e.(space.Entity))
 		}
 	})
 
-	t.Run("ErrNodeNotFound", func(t *testing.T) {
+	t.Run("ErrEntityNotFound", func(t *testing.T) {
 		s := MustNewStore(*host, *drop, t)
 		defer s.Close()
 
@@ -132,8 +132,8 @@ func TestGet(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := s.Get(context.Background(), uid); err != store.ErrNodeNotFound {
-			t.Fatalf("got: %v, want: %v", err, store.ErrNodeNotFound)
+		if _, err := s.Get(context.Background(), uid); err != store.ErrEntityNotFound {
+			t.Fatalf("got: %v, want: %v", err, store.ErrEntityNotFound)
 		}
 	})
 }
@@ -147,7 +147,7 @@ func TestDelete(t *testing.T) {
 		s := MustNewStore(*host, *drop, t)
 		defer s.Close()
 
-		obj, err := newTestObject("ent1", "entNs")
+		obj, err := newTestEntity("ent1", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -160,8 +160,8 @@ func TestDelete(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := s.Get(context.Background(), obj.UID()); err != store.ErrNodeNotFound {
-			t.Fatalf("got: %v, want: %v", err, store.ErrNodeNotFound)
+		if _, err := s.Get(context.Background(), obj.UID()); err != store.ErrEntityNotFound {
+			t.Fatalf("got: %v, want: %v", err, store.ErrEntityNotFound)
 		}
 	})
 
@@ -189,7 +189,7 @@ func TestLink(t *testing.T) {
 		s := MustNewStore(*host, *drop, t)
 		defer s.Close()
 
-		obj1, err := newTestObject("ent1", "entNs")
+		obj1, err := newTestEntity("ent1", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -198,7 +198,7 @@ func TestLink(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		obj2, err := newTestObject("ent2", "entNs")
+		obj2, err := newTestEntity("ent2", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -221,7 +221,7 @@ func TestLink(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		obj1, err := newTestObject("ent1", "entNs")
+		obj1, err := newTestEntity("ent1", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -245,7 +245,7 @@ func TestUnlink(t *testing.T) {
 		s := MustNewStore(*host, *drop, t)
 		defer s.Close()
 
-		obj1, err := newTestObject("ent1", "entNs")
+		obj1, err := newTestEntity("ent1", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -254,7 +254,7 @@ func TestUnlink(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		obj2, err := newTestObject("ent2", "entNs")
+		obj2, err := newTestEntity("ent2", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -281,7 +281,7 @@ func TestUnlink(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		obj1, err := newTestObject("ent1", "entNs")
+		obj1, err := newTestEntity("ent1", "entNs")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/store/dgraph/testdata/entity.json
+++ b/store/dgraph/testdata/entity.json
@@ -4,6 +4,7 @@
 			"xid": "ent2/entNs",
 			"name": "ent2",
 			"namespace": "entNs",
+                        "type": "Entity",
 			"links|relation": "Unknown",
 			"links|weight": 1
 		}],
@@ -11,6 +12,7 @@
 		"namespace": "entNs",
 		"resource": {
 			"xid": "nodeResUID",
+                        "type": "Resource",
 			"name": "nodeResName",
 			"group": "nodeResGroup",
 			"version": "nodeResVersion",
@@ -18,8 +20,9 @@
 			"namespaced": true
 		},
 		"xid": "ent1/entNs",
+                "type": "Entity",
 		"dgraph.type": [
-			"Object"
+			"Entity"
 		]
 	}]
 }

--- a/store/dgraph/testdata/resource.json
+++ b/store/dgraph/testdata/resource.json
@@ -4,6 +4,7 @@
 		"name": "nodeResName",
 		"namespaced": true,
 		"xid": "nodeResUID",
+                "type": "Resource",
 		"group": "nodeResGroup",
 		"kind": "nodeResKind",
 		"dgraph.type": [

--- a/store/dgraph/types.go
+++ b/store/dgraph/types.go
@@ -1,31 +1,9 @@
 package dgraph
 
-const (
-	// ObjectDType is Object entity dgraph.dtype
-	ObjectDType = "Object"
-	// ResourceDType is Resource entity dgraph.dtype
-	ResourceDType = "Resource"
-)
-
-// Op is dgraph operation.
-type Op int
-
-const (
-	// AddOp is add operation
-	AddOp Op = iota
-	// DelOp is delete operation
-	DelOp
-	// GetOp is get operation
-	GetOp
-	// LinkOp is link operation
-	LinkOp
-	// UnlinkOp is unlink operation
-	UnlinkOp
-)
-
 type Resource struct {
 	UID        string            `json:"uid,omitempty"`
 	XID        string            `json:"xid,omitempty"`
+	Type       string            `json:"type,omitempty"`
 	Name       string            `json:"name,omitempty"`
 	Group      string            `json:"group,omitempty"`
 	Version    string            `json:"version,omitempty"`
@@ -35,13 +13,14 @@ type Resource struct {
 	DType      []string          `json:"dgraph.type,omitempty"`
 }
 
-type Object struct {
+type Entity struct {
 	UID       string            `json:"uid,omitempty"`
 	XID       string            `json:"xid,omitempty"`
+	Type      string            `json:"type,omitempty"`
 	Name      string            `json:"name,omitempty"`
 	Namespace string            `json:"namespace,omitempty"`
 	Resource  *Resource         `json:"resource,omitempty"`
-	Links     []Object          `json:"links,omitempty"`
+	Links     []Entity          `json:"links,omitempty"`
 	Attrs     map[string]string `json:"attrs,omitempty"`
 	DType     []string          `json:"dgraph.type,omitempty"`
 


### PR DESCRIPTION
`space.Entity` ceases to exist in `netscrape` and was replaced by what was originally `space.Object`
`Entity` and `Resource` now both have `Type` field.